### PR TITLE
3Rfc3339 build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@
 /ebin
 /erl_crash.dump
 /rebar3.crashdump
-/rebar.lock
 /test/*.beam

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
               ]}.
 { deps
 , [ {jsx, "3.1.0"}
-  , {rfc3339, "0.2.2"}
+  , {rfc3339, {git, "git@github.com:Phonebooth/rfc3339.git", {branch, "master"}}}
   , {iso8601, {git, "git@github.com:Phonebooth/erlang_iso8601.git", {branch, "master"}}}
   ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,16 @@
+{"1.2.0",
+[{<<"iso8601">>,
+  {git,"git@github.com:Phonebooth/erlang_iso8601.git",
+       {ref,"afd51333a9569204b4ff6600b3f8fc9803338992"}},
+  0},
+ {<<"jsx">>,{pkg,<<"jsx">>,<<"3.1.0">>},0},
+ {<<"rfc3339">>,
+  {git,"git@github.com:Phonebooth/rfc3339.git",
+       {ref,"31716adecb4b405b1f5ef80b9f3fa50f39b26af8"}},
+  0}]}.
+[
+{pkg_hash,[
+ {<<"jsx">>, <<"D12516BAA0BB23A59BB35DCCAF02A1BD08243FCBB9EFE24F2D9D056CCFF71268">>}]},
+{pkg_hash_ext,[
+ {<<"jsx">>, <<"0C5CC8FDC11B53CC25CF65AC6705AD39E54ECC56D1C22E4ADB8F5A53FB9427F3">>}]}
+].


### PR DESCRIPTION
The hex.pm release of rfc3339 is at 0.2.2 and it contains Elixir build errors fixed in the official master branch. I created a Phonebooth fork to address